### PR TITLE
Restrict deploy job to main branch in publish-gh-pages workflow

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -75,8 +75,9 @@ jobs:
 
   deploy:
     name: Deploy App to GitHub Pages
+    if: github.ref == 'refs/heads/main'
     needs:
-    - build_test_artifact
+      - build_test_artifact
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request introduces a small update to the GitHub Actions workflow for deploying to GitHub Pages. The change ensures that the deployment job only runs when changes are pushed to the `main` branch, preventing deployments from other branches.

* Added a conditional (`if: github.ref == 'refs/heads/main'`) to the `deploy` job in `.github/workflows/publish-gh-pages.yml` to restrict deployments to the `main` branch.