### PR TITLE
Add 'Currently Learning' to About: model, sample data, and UI

### DIFF
--- a/src/BlazorApp/Components/About.razor
+++ b/src/BlazorApp/Components/About.razor
@@ -21,6 +21,19 @@
         </ul>
         <hr />
         <p style="padding: 1rem 3rem 0;">@aboutme.DetailOrQuote</p>
+        @if (aboutme.CurrentlyLearning is not null && aboutme.CurrentlyLearning.Any())
+        {
+            <hr />
+            <div style="padding: 1rem 3rem 0; text-align: left;">
+                <h3>Currently learning</h3>
+                <ul style="font-size: 1rem; margin-left: 1rem;">
+                @foreach (var item in aboutme.CurrentlyLearning)
+                {
+                    <li key="@item">@item</li>
+                }
+                </ul>
+            </div>
+        }
     }
     </div>
 </section>

--- a/src/BlazorApp/Models/AboutMe.cs
+++ b/src/BlazorApp/Models/AboutMe.cs
@@ -4,5 +4,6 @@ public class AboutMe
 {
     public string Description { get; set; } = string.Empty;
     public List<string> Skills { get; set; } = new();
+    public List<string> CurrentlyLearning { get; set; } = new();
     public string DetailOrQuote { get; set; } = string.Empty;
 }

--- a/src/BlazorApp/wwwroot/sample-data/aboutme.json
+++ b/src/BlazorApp/wwwroot/sample-data/aboutme.json
@@ -1,14 +1,28 @@
 {
-  "description": "I'm a .Net Software Engineer currently working at Wrede GmbH Softwarekonzepte. I enjoy coding and learing new things.",
+  "description": "I’m a passionate software engineer specializing in building robust backend systems and cross-platform mobile apps using .NET and MAUI. My focus is on creating scalable, efficient, and user-friendly solutions for modern businesses.",
   "skills": [
-    ".Net",
-    "Backend",
-    "Desktop",
-    "Xamarin",
-    "Mobile",
-    "SQL",
-    "HANA",
-    "SAP Business One"
+    "C#",
+    "JavaScript",
+    "TypeScript",
+    ".NET",
+    "ASP.NET Core",
+    "MAUI",
+    "Android",
+    "iOS",
+    "Azure",
+    "AWS (basic)",
+    "SQL Server",
+    "PostgreSQL",
+    "REST APIs",
+    "GraphQL",
+    "Docker",
+    "Git",
+    "CI/CD"
   ],
-  "detailOrQuote": ""
+  "detailOrQuote": "Code is like humor. When you have to explain it, it’s bad. — Cory House",
+  "currentlyLearning": [
+    "Kubernetes",
+    "Cloud-native .NET solutions",
+    "Advanced DevOps & automation"
+  ]
 }

--- a/src/BlazorApp/wwwroot/sample-data/projects.json
+++ b/src/BlazorApp/wwwroot/sample-data/projects.json
@@ -1,5 +1,25 @@
 [
   {
+    "title": "Cross-Platform Apps",
+    "description": "Delivering seamless experiences on Android & iOS with MAUI.",
+    "url": ""
+  },
+  {
+    "title": "Backend Services",
+    "description": "Architecting RESTful APIs and microservices with .NET.",
+    "url": ""
+  },
+  {
+    "title": "DevOps",
+    "description": "Automating deployments and maintaining code quality with CI/CD pipelines.",
+    "url": ""
+  },
+  {
+    "title": "Open Source",
+    "description": "Occasional contributor to community-driven projects.",
+    "url": ""
+  },
+  {
     "title": "This Resume Site",
     "description": "Created from githubs education/codespaces-project-template-dotnet and deployed to GitHub pages.",
     "url": "https://github.com/yannickberk/portfolio-blazor"


### PR DESCRIPTION
This pull request enhances the personal profile and project showcase features of the Blazor app. The most significant changes include updating the `AboutMe` model and sample data to provide a richer, more accurate description, introducing a new "Currently learning" section to the About page, and expanding the list of sample projects. These updates improve the clarity and depth of information presented to users.

**Profile and About page improvements:**

* Added a new `CurrentlyLearning` property to the `AboutMe` model and updated the sample data to include current learning topics. [[1]](diffhunk://#diff-bb3f7b64f314ea494dbca474f5df7f1ad8a133ceb5710e70111cdafcebf78ec0R7) [[2]](diffhunk://#diff-c3ac2f625dc81cca8dc29b8f3d25c76e89e33e634b3473a526338d3afd139d48L2-R27)
* Updated the About page (`About.razor`) to display a "Currently learning" section if relevant data is present.
* Enhanced the `description`, `skills`, and `detailOrQuote` fields in the sample data for a more comprehensive and professional profile.

**Project showcase enhancements:**

* Added several new sample projects to `projects.json`, including cross-platform apps, backend services, DevOps, and open source contributions, providing a broader overview of experience.