### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,6 @@
 name: Copilot Setup Steps
+permissions:
+  contents: read
 
 on: [workflow_dispatch]
 


### PR DESCRIPTION
Potential fix for [https://github.com/yannickberk/portfolio-blazor/security/code-scanning/21](https://github.com/yannickberk/portfolio-blazor/security/code-scanning/21)

The problem can be fixed by adding a `permissions` block to restrict the GitHub Actions token permissions to the minimal level necessary. Since the job only needs to check out code and set up SDKs (and does not interact with the repository or GitHub entities in a way that requires write permissions), setting `permissions: contents: read` at the workflow root is the safest and simplest approach. 

Insert the following block right after the `name:` and before `on:` at the top of the workflow to ensure all jobs in the workflow inherit it. This should be added as line 2, making future permission audits and maintenance easier.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
